### PR TITLE
README: add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![build status badge](https://travis-ci.org/reecehudson/taskrunner.svg "build status image")
 # Taskrunner #
 ***
 ## API ##


### PR DESCRIPTION
Adds a status image from [Travis-CI](https://travis-ci.org)
